### PR TITLE
update to stable version of builders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
-                "@discordjs/builders": "^0.14.0-dev.1652573539-7ce641d",
+                "@discordjs/builders": "^0.14.0",
                 "@discordjs/rest": "^0.4.1",
                 "bufferutil": "^4.0.6",
                 "canvas": "^2.9.1",
@@ -34,6 +34,7 @@
                 "eslint": "^8.15.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.0.0",
+                "resolve-tspaths": "^0.6.0",
                 "typescript": "^4.6.4"
             },
             "engines": {
@@ -52,20 +53,25 @@
             }
         },
         "node_modules/@discordjs/builders": {
-            "version": "0.14.0-dev.1652573539-7ce641d",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0-dev.1652573539-7ce641d.tgz",
-            "integrity": "sha512-qZI7RFf0zPN3HIbPm2qpFmT3bregP2AibnBZjHD6xYmtPZv9HucFqfSDRO35S2Hcq06l0V7J3CjvkIBJ7JkeRQ==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+            "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
             "dependencies": {
-                "@sapphire/shapeshift": "^3.0.0",
+                "@sapphire/shapeshift": "^3.1.0",
                 "@sindresorhus/is": "^4.6.0",
-                "discord-api-types": "^0.32.1",
+                "discord-api-types": "^0.33.3",
                 "fast-deep-equal": "^3.1.3",
                 "ts-mixer": "^6.0.1",
-                "tslib": "^2.3.1"
+                "tslib": "^2.4.0"
             },
             "engines": {
                 "node": ">=16.9.0"
             }
+        },
+        "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+            "version": "0.33.3",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.3.tgz",
+            "integrity": "sha512-P3A1RJXKEDmGPHrFTN5+gYLsBPGUVGj+D3+fa3m0K/umc+LMfqGuEad+p7cNq7ry/icReVhS3bz9jvBvne/BRA=="
         },
         "node_modules/@discordjs/collection": {
             "version": "0.6.0",
@@ -210,9 +216,9 @@
             }
         },
         "node_modules/@sapphire/shapeshift": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.0.0.tgz",
-            "integrity": "sha512-LTVj/a70UDzjOFaViMGpVzSzKYD2pBk0TmZIHnBf4vnytV7TK/L6XVN6hslq7R+qwRZyL/mzIldu6mAV6r7vzA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.1.0.tgz",
+            "integrity": "sha512-PkxFXd3QJ1qAPS05Dy2UkVGYPm/asF1Ugt2Xyzmv4DHzO3+G7l+873C4XFFcJ9M5Je+eCMC7SSifgPTSur5QuA==",
             "engines": {
                 "node": ">=v15.0.0",
                 "npm": ">=7.0.0"
@@ -536,6 +542,15 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -732,6 +747,15 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+            "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/concat-map": {
@@ -2097,6 +2121,23 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-tspaths": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.6.0.tgz",
+            "integrity": "sha512-8N7vpLOR+5Xn1AWWz5FmE5IdIJk1tQZCq7EUCpIsM0YkQQ8/nXyNj+D/aG5MsnmjbQZBO1evG2P86zVYCBA6Hg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-colors": "4.1.3",
+                "commander": "9.2.0",
+                "fast-glob": "3.2.11"
+            },
+            "bin": {
+                "resolve-tspaths": "dist/main.js"
+            },
+            "peerDependencies": {
+                "typescript": ">=3.0.3"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2355,9 +2396,9 @@
             "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -2553,16 +2594,23 @@
             }
         },
         "@discordjs/builders": {
-            "version": "0.14.0-dev.1652573539-7ce641d",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0-dev.1652573539-7ce641d.tgz",
-            "integrity": "sha512-qZI7RFf0zPN3HIbPm2qpFmT3bregP2AibnBZjHD6xYmtPZv9HucFqfSDRO35S2Hcq06l0V7J3CjvkIBJ7JkeRQ==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+            "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
             "requires": {
-                "@sapphire/shapeshift": "^3.0.0",
+                "@sapphire/shapeshift": "^3.1.0",
                 "@sindresorhus/is": "^4.6.0",
-                "discord-api-types": "^0.32.1",
+                "discord-api-types": "^0.33.3",
                 "fast-deep-equal": "^3.1.3",
                 "ts-mixer": "^6.0.1",
-                "tslib": "^2.3.1"
+                "tslib": "^2.4.0"
+            },
+            "dependencies": {
+                "discord-api-types": {
+                    "version": "0.33.3",
+                    "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.3.tgz",
+                    "integrity": "sha512-P3A1RJXKEDmGPHrFTN5+gYLsBPGUVGj+D3+fa3m0K/umc+LMfqGuEad+p7cNq7ry/icReVhS3bz9jvBvne/BRA=="
+                }
             }
         },
         "@discordjs/collection": {
@@ -2679,9 +2727,9 @@
             "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
         },
         "@sapphire/shapeshift": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.0.0.tgz",
-            "integrity": "sha512-LTVj/a70UDzjOFaViMGpVzSzKYD2pBk0TmZIHnBf4vnytV7TK/L6XVN6hslq7R+qwRZyL/mzIldu6mAV6r7vzA=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.1.0.tgz",
+            "integrity": "sha512-PkxFXd3QJ1qAPS05Dy2UkVGYPm/asF1Ugt2Xyzmv4DHzO3+G7l+873C4XFFcJ9M5Je+eCMC7SSifgPTSur5QuA=="
         },
         "@sapphire/snowflake": {
             "version": "3.2.1",
@@ -2886,6 +2934,12 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true
+        },
         "ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3033,6 +3087,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+            "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
@@ -4032,6 +4092,17 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
         },
+        "resolve-tspaths": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.6.0.tgz",
+            "integrity": "sha512-8N7vpLOR+5Xn1AWWz5FmE5IdIJk1tQZCq7EUCpIsM0YkQQ8/nXyNj+D/aG5MsnmjbQZBO1evG2P86zVYCBA6Hg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "4.1.3",
+                "commander": "9.2.0",
+                "fast-glob": "3.2.11"
+            }
+        },
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4199,9 +4270,9 @@
             "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "tsutils": {
             "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "homepage": "https://github.com/Fluorinebot/fluorine/#readme",
     "dependencies": {
-        "@discordjs/builders": "^0.14.0-dev.1652573539-7ce641d",
+        "@discordjs/builders": "^0.14.0",
         "@discordjs/rest": "^0.4.1",
         "bufferutil": "^4.0.6",
         "canvas": "^2.9.1",
@@ -53,6 +53,7 @@
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "resolve-tspaths": "^0.6.0",
         "typescript": "^4.6.4"
     },
     "engines": {


### PR DESCRIPTION
also adds `resolve-tspaths` as a dev dependency so it doesn't have to be installed separately