### PR TITLE
remove `resolve-tspaths` dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
                 "prisma": "^4.1.0",
-                "resolve-tspaths": "^0.7.1",
                 "typescript": "^4.7.4"
             },
             "engines": {
@@ -517,15 +516,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -698,15 +688,6 @@
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "bin": {
                 "color-support": "bin.js"
-            }
-        },
-        "node_modules/commander": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-            "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/concat-map": {
@@ -1973,23 +1954,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/resolve-tspaths": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.7.1.tgz",
-            "integrity": "sha512-clbzO4S/t827kA528ds2j0CJ26UZfRAIYl0hGzuCwlWywgSX3z966dp+nq0Tg2VT9Ws2WgNFDGEycUSqJitfgA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-colors": "4.1.3",
-                "commander": "9.4.0",
-                "fast-glob": "3.2.11"
-            },
-            "bin": {
-                "resolve-tspaths": "dist/main.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=3.0.3"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2780,12 +2744,6 @@
                 "uri-js": "^4.2.2"
             }
         },
-        "ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true
-        },
         "ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2915,12 +2873,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
-        "commander": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-            "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
-            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
@@ -3825,17 +3777,6 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
-        },
-        "resolve-tspaths": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.7.1.tgz",
-            "integrity": "sha512-clbzO4S/t827kA528ds2j0CJ26UZfRAIYl0hGzuCwlWywgSX3z966dp+nq0Tg2VT9Ws2WgNFDGEycUSqJitfgA==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "4.1.3",
-                "commander": "9.4.0",
-                "fast-glob": "3.2.11"
-            }
         },
         "reusify": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,15 @@
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",
         "dev": "npm run build && npm start",
-        "build": "rm -rf ./dist/ && tsc && resolve-tspaths",
+        "build": "rm -rf ./dist/ && tsc",
         "start": "node --enable-source-maps ."
+    },
+    "imports": {
+        "#classes/*": "./dist/classes/*.js",
+        "#handlers/*": "./dist/classes/handlers/*.js",
+        "#modules/*": "./dist/classes/modules/*.js",
+        "#types/*": "./dist/types/*.js",
+        "#util/*": "./dist/util/*.js"
     },
     "repository": {
         "type": "git",
@@ -51,7 +58,6 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prisma": "^4.1.0",
-        "resolve-tspaths": "^0.7.1",
         "typescript": "^4.7.4"
     },
     "engines": {

--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -3,23 +3,23 @@ import i18next from 'i18next';
 import Backend from 'i18next-fs-backend';
 import { REST } from '@discordjs/rest';
 
-import { Logger } from '@classes/Logger';
+import { Logger } from '#classes/Logger';
 import { join } from 'path';
 import { bold, red } from 'picocolors';
 import { performance } from 'perf_hooks';
 
 import { PrismaClient } from '@prisma/client';
 
-import EventHandler from '@handlers/EventHandler';
-import CommandHandler from '@classes/handlers/CommandHandler';
-import ComponentHandler from '@handlers/ComponentHandler';
-import CooldownHandler from '@handlers/CooldownHandler';
+import EventHandler from '#handlers/EventHandler';
+import CommandHandler from '#classes/handlers/CommandHandler';
+import ComponentHandler from '#handlers/ComponentHandler';
+import CooldownHandler from '#handlers/CooldownHandler';
 
-import AIModule from '@modules/AIModule';
-import EconomyModule from '@modules/EconomyModule';
-import ShopModule from '@modules/ShopModule';
-import PhishingModule from '@modules/PhishingModule';
-import CasesModule from '@modules/CasesModule';
+import AIModule from '#modules/AIModule';
+import EconomyModule from '#modules/EconomyModule';
+import ShopModule from '#modules/ShopModule';
+import PhishingModule from '#modules/PhishingModule';
+import CasesModule from '#modules/CasesModule';
 
 export default class FluorineClient extends Client {
     createdAt = performance.now();

--- a/src/classes/Embed.ts
+++ b/src/classes/Embed.ts
@@ -1,5 +1,5 @@
 import { ColorResolvable, EmbedBuilder } from 'discord.js';
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import i18next from 'i18next';
 
 export interface LocaleFieldOptions {

--- a/src/classes/handlers/CommandHandler.ts
+++ b/src/classes/handlers/CommandHandler.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import { ChatInputCommand, ChatInputSubcommand, ContextMenuCommand } from 'types/structures';
-import { loadDirectory, loadParentDirectory } from '@util/files';
+import FluorineClient from '#classes/Client';
+import { ChatInputCommand, ChatInputSubcommand, ContextMenuCommand } from '#types/structures';
+import { loadDirectory, loadParentDirectory } from '#util/files';
 import { Collection, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export default class CommandHandler {

--- a/src/classes/handlers/ComponentHandler.ts
+++ b/src/classes/handlers/ComponentHandler.ts
@@ -1,7 +1,7 @@
-import { Component } from 'types/structures';
+import { Component } from '#types/structures';
 import { Collection } from 'discord.js';
-import FluorineClient from '@classes/Client';
-import { loadDirectory } from '@util/files';
+import FluorineClient from '#classes/Client';
+import { loadDirectory } from '#util/files';
 
 export default class ComponentHandler extends Collection<string, Component> {
     constructor(private client: FluorineClient) {

--- a/src/classes/handlers/CooldownHandler.ts
+++ b/src/classes/handlers/CooldownHandler.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Prisma } from '@prisma/client';
 import { User } from 'discord.js';
 

--- a/src/classes/handlers/EventHandler.ts
+++ b/src/classes/handlers/EventHandler.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import { loadDirectory } from '@util/files';
-import { Event } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import { loadDirectory } from '#util/files';
+import { Event } from '#types/structures';
 
 export default class EventHandler {
     constructor(private client: FluorineClient) {

--- a/src/classes/modules/AIModule.ts
+++ b/src/classes/modules/AIModule.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { CommandInteraction, ContextMenuCommandInteraction } from 'discord.js';
-import Embed from '@classes/Embed';
-import { AIQueue } from 'types/structures';
+import Embed from '#classes/Embed';
+import { AIQueue } from '#types/structures';
 
 export default class AIModule {
     queue: AIQueue[];

--- a/src/classes/modules/CasesModule.ts
+++ b/src/classes/modules/CasesModule.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { Prisma } from '@prisma/client';
 import { User } from 'discord.js';
 

--- a/src/classes/modules/EconomyModule.ts
+++ b/src/classes/modules/EconomyModule.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { EconomyProfile, Prisma } from '@prisma/client';
 import { User } from 'discord.js';
 

--- a/src/classes/modules/PhishingModule.ts
+++ b/src/classes/modules/PhishingModule.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Message } from 'discord.js';
 import { readFileSync } from 'fs';
-import { PhishingLink } from 'types/structures';
+import { PhishingLink } from '#types/structures';
 
 export default class PhishingModule {
     private _words: string;

--- a/src/classes/modules/ShopModule.ts
+++ b/src/classes/modules/ShopModule.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Prisma } from '@prisma/client';
-import { ShopItemConstructor } from 'types/structures';
+import { ShopItemConstructor } from '#types/structures';
 
 export default class ShopModule {
     table: Prisma.ShopItemDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation>;

--- a/src/commands/8ball.ts
+++ b/src/commands/8ball.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import hash from 'murmurhash-v3';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 

--- a/src/commands/ai.ts
+++ b/src/commands/ai.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/avatar.ts
+++ b/src/commands/avatar.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ChatInputCommandInteraction, GuildMember, InteractionReplyOptions, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
-import { getComponents, getEmbed } from '@util/avatar';
+import { Category } from '#types/structures';
+import { getComponents, getEmbed } from '#util/avatar';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const user = interaction.options.getMember('user') ?? interaction.options.getUser('user') ?? interaction.member;

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,7 +1,7 @@
 import FluorineClient from '../classes/Client';
 import Embed from '../classes/Embed';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/bedwars.ts
+++ b/src/commands/bedwars.ts
@@ -1,8 +1,8 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { HypixelType } from 'types/hypixel';
-import { Category } from 'types/structures';
-import { UUIDResponse } from 'types/webRequests';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { HypixelType } from '#types/hypixel';
+import { Category } from '#types/structures';
+import { UUIDResponse } from '#types/webRequests';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/birb.ts
+++ b/src/commands/birb.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/case/index.ts
+++ b/src/commands/case/index.ts
@@ -1,4 +1,4 @@
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/case/list.ts
+++ b/src/commands/case/list.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { splitArray } from '@util/splitArr';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { splitArray } from '#util/splitArr';
 import {
     ActionRowBuilder,
     ButtonBuilder,

--- a/src/commands/case/view.ts
+++ b/src/commands/case/view.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/cat.ts
+++ b/src/commands/cat.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/antibot-action.ts
+++ b/src/commands/config/antibot-action.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/antibot.ts
+++ b/src/commands/config/antibot.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/currency.ts
+++ b/src/commands/config/currency.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,4 +1,4 @@
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/config/logs-channel.ts
+++ b/src/commands/config/logs-channel.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChannelType, ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/logs.ts
+++ b/src/commands/config/logs.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/mod-logs.ts
+++ b/src/commands/config/mod-logs.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/config/prefix.ts
+++ b/src/commands/config/prefix.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/crime.ts
+++ b/src/commands/crime.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import Embed from '@classes/Embed';
+import Embed from '#classes/Embed';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const currency = await client.economy.getCurrency(interaction.guildId);

--- a/src/commands/deploy/create.ts
+++ b/src/commands/deploy/create.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/deploy/delete.ts
+++ b/src/commands/deploy/delete.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder().setName('deploy').setDescription('Deploy application commands');
 

--- a/src/commands/deposit.ts
+++ b/src/commands/deposit.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/dev/eval.ts
+++ b/src/commands/dev/eval.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { clean } from '@util/clean';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { clean } from '#util/clean';
 import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder()
     .setName('dev')

--- a/src/commands/dev/reload.ts
+++ b/src/commands/dev/reload.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import EventHandler from '@handlers/EventHandler';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import EventHandler from '#handlers/EventHandler';
 import { execSync } from 'child_process';
 import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 import { readdir } from 'fs/promises';

--- a/src/commands/dev/shell.ts
+++ b/src/commands/dev/shell.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { execSync } from 'child_process';
 import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 

--- a/src/commands/dev/sql.ts
+++ b/src/commands/dev/sql.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { clean } from '@util/clean';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { clean } from '#util/clean';
 import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/dev/update.ts
+++ b/src/commands/dev/update.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { execSync } from 'child_process';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 

--- a/src/commands/dog.ts
+++ b/src/commands/dog.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const { file } = (await fetch('https://api.alexflipnote.dev/dogs').then(response => response.json())) as {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import {
     ActionRowBuilder,
     APIEmbedField,
@@ -7,7 +7,7 @@ import {
     SelectMenuBuilder,
     SlashCommandBuilder
 } from 'discord.js';
-import { Category, ChatInputCommand } from 'types/structures';
+import { Category, ChatInputCommand } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const category = interaction.options.getString('category');

--- a/src/commands/howgay.ts
+++ b/src/commands/howgay.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import hash from 'murmurhash-v3';
 

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import { getComponents, getEmbed } from '@util/info';
+import FluorineClient from '#classes/Client';
+import { getComponents, getEmbed } from '#util/info';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     interaction.reply({

--- a/src/commands/inpost.ts
+++ b/src/commands/inpost.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { InpostStatuses, InpostTrackObj } from 'types/webRequests';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { InpostStatuses, InpostTrackObj } from '#types/webRequests';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -1,6 +1,6 @@
 import FluorineClient from '../classes/Client';
 import Embed from '../classes/Embed';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const embed = new Embed(client, interaction.locale)

--- a/src/commands/profile/index.ts
+++ b/src/commands/profile/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder()
     .setName('profile')

--- a/src/commands/profile/set.ts
+++ b/src/commands/profile/set.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/profile/view.ts
+++ b/src/commands/profile/view.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { fragmentText } from '@util/fragmentText';
+import FluorineClient from '#classes/Client';
+import { fragmentText } from '#util/fragmentText';
 import canvas from 'canvas';
 import { AttachmentBuilder, CommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 

--- a/src/commands/rob.ts
+++ b/src/commands/rob.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import { Category } from 'types/structures';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import { Category } from '#types/structures';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/serverinfo.ts
+++ b/src/commands/serverinfo.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/shop/buy.ts
+++ b/src/commands/shop/buy.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {

--- a/src/commands/shop/create.ts
+++ b/src/commands/shop/create.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { ShopItemConstructor } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { ShopItemConstructor } from '#types/structures';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/shop/delete.ts
+++ b/src/commands/shop/delete.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/shop/index.ts
+++ b/src/commands/shop/index.ts
@@ -1,4 +1,4 @@
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 import { SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/shop/list.ts
+++ b/src/commands/shop/list.ts
@@ -1,6 +1,6 @@
 import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const list = await client.shop.list(interaction.guildId);

--- a/src/commands/skywars.ts
+++ b/src/commands/skywars.ts
@@ -1,9 +1,9 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { HypixelType } from 'types/hypixel';
-import { Category } from 'types/structures';
-import { UUIDResponse } from 'types/webRequests';
+import { HypixelType } from '#types/hypixel';
+import { Category } from '#types/structures';
+import { UUIDResponse } from '#types/webRequests';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const player = interaction.options.getString('player');

--- a/src/commands/slut.ts
+++ b/src/commands/slut.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const embed = new Embed(client, interaction.locale)

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -2,7 +2,7 @@ import FluorineClient from '../classes/Client';
 import Embed from '../classes/Embed';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import ms, { StringValue } from 'ms';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -1,7 +1,7 @@
 import FluorineClient from '../classes/Client';
 import Embed from '../classes/Embed';
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/withdraw.ts
+++ b/src/commands/withdraw.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from 'types/structures';
+import { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const toWithdraw = interaction.options.getInteger('amount');

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { Category } from 'types/structures';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { Category } from '#types/structures';
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/components/avatar.ts
+++ b/src/components/avatar.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { getComponents, getEmbed } from '@util/avatar';
+import FluorineClient from '#classes/Client';
+import { getComponents, getEmbed } from '#util/avatar';
 import { ButtonInteraction } from 'discord.js';
 
 export const authorOnly = true;

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ActionRowBuilder, APIEmbedField, SelectMenuBuilder, SelectMenuInteraction } from 'discord.js';
-import { ChatInputCommand } from 'types/structures';
+import { ChatInputCommand } from '#types/structures';
 
 export const authorOnly = true;
 

--- a/src/components/info.ts
+++ b/src/components/info.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { getEmbed, getComponents } from '@util/info';
+import FluorineClient from '#classes/Client';
+import { getEmbed, getComponents } from '#util/info';
 import { ButtonInteraction } from 'discord.js';
 
 export const authorOnly = true;

--- a/src/components/listcase.ts
+++ b/src/components/listcase.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
-import { splitArray } from '@util/splitArr';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { splitArray } from '#util/splitArr';
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
 
 export const authorOnly = true;

--- a/src/context/ai.ts
+++ b/src/context/ai.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ApplicationCommandType, ContextMenuCommandBuilder, MessageContextMenuCommandInteraction } from 'discord.js';
 export async function run(client: FluorineClient, interaction: MessageContextMenuCommandInteraction) {
     const { content } = interaction.targetMessage;

--- a/src/context/avatar.ts
+++ b/src/context/avatar.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import { getComponents, getEmbed } from '@util/avatar';
+import FluorineClient from '#classes/Client';
+import { getComponents, getEmbed } from '#util/avatar';
 import {
     ApplicationCommandType,
     ContextMenuCommandBuilder,

--- a/src/context/howgay.ts
+++ b/src/context/howgay.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ApplicationCommandType, ContextMenuCommandBuilder, UserContextMenuCommandInteraction } from 'discord.js';
 import hash from 'murmurhash-v3';
 

--- a/src/context/list-cases.ts
+++ b/src/context/list-cases.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import {
     ActionRowBuilder,
     ApplicationCommandType,
@@ -10,7 +10,7 @@ import {
     PermissionFlagsBits,
     UserContextMenuCommandInteraction
 } from 'discord.js';
-import { splitArray } from '@util/splitArr';
+import { splitArray } from '#util/splitArr';
 
 export async function run(client: FluorineClient, interaction: UserContextMenuCommandInteraction<'cached'>) {
     const row = new ActionRowBuilder<ButtonBuilder>();

--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Guild } from 'discord.js';
 
 export async function run(client: FluorineClient, guild: Guild) {

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Interaction, InteractionType } from 'discord.js';
-import { ChatInputCommand } from 'types/structures';
+import { ChatInputCommand } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: Interaction) {
     if (interaction.type === InteractionType.MessageComponent) {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Message, OAuth2Scopes } from 'discord.js';
 
 export async function run(client: FluorineClient, message: Message) {

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { Message } from 'discord.js';
 
 export async function run(client: FluorineClient, message: Message) {

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { Message } from 'discord.js';
 
 export async function run(client: FluorineClient, oldMessage: Message, newMessage: Message) {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { Routes } from 'discord.js';
 import { performance } from 'perf_hooks';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import 'dotenv/config';
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 
 new FluorineClient().init();

--- a/src/types/structures.ts
+++ b/src/types/structures.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import {
     CommandInteraction,
     ContextMenuCommandBuilder,

--- a/src/util/avatar.ts
+++ b/src/util/avatar.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, GuildMember, Interaction, User } from 'discord.js';
 
 export function getComponents(

--- a/src/util/clean.ts
+++ b/src/util/clean.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '@classes/Client';
+import FluorineClient from '#classes/Client';
 import { inspect } from 'util';
 
 export async function clean(client: FluorineClient, text: unknown): Promise<string> {

--- a/src/util/info.ts
+++ b/src/util/info.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '@classes/Client';
-import Embed from '@classes/Embed';
+import FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Interaction } from 'discord.js';
 import { join } from 'path';
 import { readdir } from 'fs/promises';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,11 @@
         "moduleResolution": "node",
         "baseUrl": "src",
         "paths": {
-            "@classes/*": ["classes/*"],
-            "@handlers/*": ["classes/handlers/*"],
-            "@modules/*": ["classes/modules/*"],
-            "@util/*": ["util/*"],
-            "types/*": ["types/*"]
+            "#classes/*": ["classes/*"],
+            "#handlers/*": ["classes/handlers/*"],
+            "#modules/*": ["classes/modules/*"],
+            "#util/*": ["util/*"],
+            "#types/*": ["types/*"]
         },
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,


### PR DESCRIPTION
replaces all `@` based imports with `#` for consistency, since typescript doesn't allow custom `@types/` imports