### PR TITLE
enforce consistent type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "plugins": ["@typescript-eslint", "prettier"],
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/consistent-type-imports": "error",
         "@typescript-eslint/no-explicit-any": "off",
         "array-bracket-newline": ["error", "consistent"],
         "arrow-body-style": ["error", "as-needed"],

--- a/src/classes/Embed.ts
+++ b/src/classes/Embed.ts
@@ -1,6 +1,6 @@
-import { ColorResolvable, EmbedBuilder } from 'discord.js';
-import FluorineClient from '#classes/Client';
-import i18next from 'i18next';
+import type FluorineClient from '#classes/Client';
+import { type ColorResolvable, EmbedBuilder } from 'discord.js';
+import type i18next from 'i18next';
 
 export interface LocaleFieldOptions {
     name: string;

--- a/src/classes/handlers/CommandHandler.ts
+++ b/src/classes/handlers/CommandHandler.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
-import { ChatInputCommand, ChatInputSubcommand, ContextMenuCommand } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import type { ChatInputCommand, ChatInputSubcommand, ContextMenuCommand } from '#types/structures';
 import { loadDirectory, loadParentDirectory } from '#util/files';
-import { Collection, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
+import { Collection, type SlashCommandBuilder, type SlashCommandSubcommandBuilder } from 'discord.js';
 
 export default class CommandHandler {
     chatInput = new Collection<string, ChatInputCommand | ChatInputSubcommand>();

--- a/src/classes/handlers/ComponentHandler.ts
+++ b/src/classes/handlers/ComponentHandler.ts
@@ -1,6 +1,6 @@
-import { Component } from '#types/structures';
+import type { Component } from '#types/structures';
 import { Collection } from 'discord.js';
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { loadDirectory } from '#util/files';
 
 export default class ComponentHandler extends Collection<string, Component> {

--- a/src/classes/handlers/CooldownHandler.ts
+++ b/src/classes/handlers/CooldownHandler.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Prisma } from '@prisma/client';
-import { User } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Prisma } from '@prisma/client';
+import type { User } from 'discord.js';
 
 export default class CooldownHandler {
     table: Prisma.CooldownDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation>;

--- a/src/classes/handlers/EventHandler.ts
+++ b/src/classes/handlers/EventHandler.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { loadDirectory } from '#util/files';
-import { Event } from '#types/structures';
+import type { Event } from '#types/structures';
 
 export default class EventHandler {
     constructor(private client: FluorineClient) {

--- a/src/classes/modules/AIModule.ts
+++ b/src/classes/modules/AIModule.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
-import { CommandInteraction, ContextMenuCommandInteraction } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { CommandInteraction, ContextMenuCommandInteraction } from 'discord.js';
 import Embed from '#classes/Embed';
-import { AIQueue } from '#types/structures';
+import type { AIQueue } from '#types/structures';
 
 export default class AIModule {
     queue: AIQueue[];

--- a/src/classes/modules/CasesModule.ts
+++ b/src/classes/modules/CasesModule.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Prisma } from '@prisma/client';
-import { User } from 'discord.js';
+import type { Prisma } from '@prisma/client';
+import type { User } from 'discord.js';
 
 export default class CasesModule {
     table: Prisma.CaseDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation>;

--- a/src/classes/modules/EconomyModule.ts
+++ b/src/classes/modules/EconomyModule.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { EconomyProfile, Prisma } from '@prisma/client';
-import { User } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { EconomyProfile, Prisma } from '@prisma/client';
+import type { User } from 'discord.js';
 
 export default class EconomyModule {
     table: Prisma.EconomyProfileDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation>;

--- a/src/classes/modules/PhishingModule.ts
+++ b/src/classes/modules/PhishingModule.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
-import { Message } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Message } from 'discord.js';
 import { readFileSync } from 'fs';
-import { PhishingLink } from '#types/structures';
+import type { PhishingLink } from '#types/structures';
 
 export default class PhishingModule {
     private _words: string;

--- a/src/classes/modules/ShopModule.ts
+++ b/src/classes/modules/ShopModule.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Prisma } from '@prisma/client';
-import { ShopItemConstructor } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import type { Prisma } from '@prisma/client';
+import type { ShopItemConstructor } from '#types/structures';
 
 export default class ShopModule {
     table: Prisma.ShopItemDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation>;

--- a/src/commands/8ball.ts
+++ b/src/commands/8ball.ts
@@ -1,8 +1,8 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 import hash from 'murmurhash-v3';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const question = interaction.options.getString('question');

--- a/src/commands/ai.ts
+++ b/src/commands/ai.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const args = interaction.options.getString('start');

--- a/src/commands/avatar.ts
+++ b/src/commands/avatar.ts
@@ -1,7 +1,12 @@
-import FluorineClient from '#classes/Client';
-import { ChatInputCommandInteraction, GuildMember, InteractionReplyOptions, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
 import { getComponents, getEmbed } from '#util/avatar';
+import {
+    type ChatInputCommandInteraction,
+    GuildMember,
+    type InteractionReplyOptions,
+    SlashCommandBuilder
+} from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const user = interaction.options.getMember('user') ?? interaction.options.getUser('user') ?? interaction.member;

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const balance = await client.economy.get(interaction.guildId, interaction.user);

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '../classes/Client';
-import Embed from '../classes/Embed';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/bedwars.ts
+++ b/src/commands/bedwars.ts
@@ -1,9 +1,9 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { HypixelType } from '#types/hypixel';
-import { Category } from '#types/structures';
-import { UUIDResponse } from '#types/webRequests';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { HypixelType } from '#types/hypixel';
+import type { Category } from '#types/structures';
+import type { UUIDResponse } from '#types/webRequests';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const player = interaction.options.getString('player');

--- a/src/commands/birb.ts
+++ b/src/commands/birb.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const { file } = (await fetch('https://api.alexflipnote.dev/birb').then(response => response.json())) as {

--- a/src/commands/case/index.ts
+++ b/src/commands/case/index.ts
@@ -1,4 +1,4 @@
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/case/list.ts
+++ b/src/commands/case/list.ts
@@ -1,12 +1,12 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import { splitArray } from '#util/splitArr';
 import {
     ActionRowBuilder,
     ButtonBuilder,
     ButtonStyle,
-    ChatInputCommandInteraction,
-    InteractionReplyOptions,
+    type ChatInputCommandInteraction,
+    type InteractionReplyOptions,
     SlashCommandSubcommandBuilder
 } from 'discord.js';
 

--- a/src/commands/case/view.ts
+++ b/src/commands/case/view.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const id = interaction.options.getInteger('id');

--- a/src/commands/cat.ts
+++ b/src/commands/cat.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const { file } = (await fetch('https://api.alexflipnote.dev/cats').then(response => response.json())) as {

--- a/src/commands/config/antibot-action.ts
+++ b/src/commands/config/antibot-action.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getString('action');

--- a/src/commands/config/antibot.ts
+++ b/src/commands/config/antibot.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getInteger('factor');

--- a/src/commands/config/currency.ts
+++ b/src/commands/config/currency.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getString('currency');

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,4 +1,4 @@
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/config/logs-channel.ts
+++ b/src/commands/config/logs-channel.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChannelType, ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, ChannelType, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getChannel('channel').id;

--- a/src/commands/config/logs.ts
+++ b/src/commands/config/logs.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getBoolean('logs');

--- a/src/commands/config/mod-logs.ts
+++ b/src/commands/config/mod-logs.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getBoolean('mod-logs');

--- a/src/commands/config/prefix.ts
+++ b/src/commands/config/prefix.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const value = interaction.options.getString('prefix');

--- a/src/commands/crime.ts
+++ b/src/commands/crime.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import Embed from '#classes/Embed';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/deploy/create.ts
+++ b/src/commands/deploy/create.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/deploy/delete.ts
+++ b/src/commands/deploy/delete.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, Routes, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder().setName('deploy').setDescription('Deploy application commands');
 

--- a/src/commands/deposit.ts
+++ b/src/commands/deposit.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const toDeposit = interaction.options.getInteger('amount');

--- a/src/commands/dev/eval.ts
+++ b/src/commands/dev/eval.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import { clean } from '#util/clean';
-import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder()
     .setName('dev')

--- a/src/commands/dev/reload.ts
+++ b/src/commands/dev/reload.ts
@@ -1,8 +1,8 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import EventHandler from '#handlers/EventHandler';
 import { execSync } from 'child_process';
-import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 import { readdir } from 'fs/promises';
 import { join } from 'path';
 

--- a/src/commands/dev/shell.ts
+++ b/src/commands/dev/shell.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import { execSync } from 'child_process';
-import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/dev/sql.ts
+++ b/src/commands/dev/sql.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import { clean } from '#util/clean';
-import { ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, codeBlock, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/dev/update.ts
+++ b/src/commands/dev/update.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { execSync } from 'child_process';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     await interaction.deferReply();

--- a/src/commands/dog.ts
+++ b/src/commands/dog.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const { file } = (await fetch('https://api.alexflipnote.dev/dogs').then(response => response.json())) as {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,13 +1,13 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
+import type { Category, ChatInputCommand } from '#types/structures';
 import {
     ActionRowBuilder,
-    APIEmbedField,
-    ChatInputCommandInteraction,
+    type APIEmbedField,
+    type ChatInputCommandInteraction,
     SelectMenuBuilder,
     SlashCommandBuilder
 } from 'discord.js';
-import { Category, ChatInputCommand } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const category = interaction.options.getString('category');

--- a/src/commands/howgay.ts
+++ b/src/commands/howgay.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import hash from 'murmurhash-v3';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { getComponents, getEmbed } from '#util/info';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     interaction.reply({

--- a/src/commands/inpost.ts
+++ b/src/commands/inpost.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { InpostStatuses, InpostTrackObj } from '#types/webRequests';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { InpostStatuses, InpostTrackObj } from '#types/webRequests';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const id = interaction.options.getString('id');

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '../classes/Client';
-import Embed from '../classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const embed = new Embed(client, interaction.locale)

--- a/src/commands/profile/index.ts
+++ b/src/commands/profile/index.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 
 export const data = new SlashCommandBuilder()
     .setName('profile')

--- a/src/commands/profile/set.ts
+++ b/src/commands/profile/set.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const table = client.prisma.profile;

--- a/src/commands/profile/view.ts
+++ b/src/commands/profile/view.ts
@@ -1,9 +1,9 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { fragmentText } from '#util/fragmentText';
 import canvas from 'canvas';
-import { AttachmentBuilder, CommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import { AttachmentBuilder, type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
-export async function run(client: FluorineClient, interaction: CommandInteraction) {
+export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const user = interaction.options.getUser('user') ?? interaction.user;
     const localeOptions = {
         lng: interaction.locale

--- a/src/commands/rob.ts
+++ b/src/commands/rob.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import type { Category } from '#types/structures';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const user = interaction.options.getUser('user');

--- a/src/commands/serverinfo.ts
+++ b/src/commands/serverinfo.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const embed = new Embed(client, interaction.locale).setLocaleTitle('SERVER_INFO').addLocaleFields([

--- a/src/commands/shop/buy.ts
+++ b/src/commands/shop/buy.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const item = interaction.options.getString('item');

--- a/src/commands/shop/create.ts
+++ b/src/commands/shop/create.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ShopItemConstructor } from '#types/structures';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
+import type { ShopItemConstructor } from '#types/structures';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const name = interaction.options.getString('name');

--- a/src/commands/shop/delete.ts
+++ b/src/commands/shop/delete.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandSubcommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const name = interaction.options.getString('name');

--- a/src/commands/shop/index.ts
+++ b/src/commands/shop/index.ts
@@ -1,4 +1,4 @@
-import { Category } from '#types/structures';
+import type { Category } from '#types/structures';
 import { SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()

--- a/src/commands/shop/list.ts
+++ b/src/commands/shop/list.ts
@@ -1,5 +1,5 @@
-import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
-import FluorineClient from '#classes/Client';
+import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {

--- a/src/commands/skywars.ts
+++ b/src/commands/skywars.ts
@@ -1,9 +1,9 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { HypixelType } from '#types/hypixel';
-import { Category } from '#types/structures';
-import { UUIDResponse } from '#types/webRequests';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { HypixelType } from '#types/hypixel';
+import type { Category } from '#types/structures';
+import type { UUIDResponse } from '#types/webRequests';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const player = interaction.options.getString('player');

--- a/src/commands/slut.ts
+++ b/src/commands/slut.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const money = Math.floor(Math.random() * 200 + 50);

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const embed = new Embed(client, interaction.locale)

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -1,8 +1,8 @@
-import FluorineClient from '../classes/Client';
-import Embed from '../classes/Embed';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import ms, { StringValue } from 'ms';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import ms, { type StringValue } from 'ms';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '../classes/Client';
-import Embed from '../classes/Embed';
-import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import Embed from '#classes/Embed';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction<'cached'>) {
     const member = interaction.options.getMember('user');

--- a/src/commands/withdraw.ts
+++ b/src/commands/withdraw.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { Category } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const toWithdraw = interaction.options.getInteger('amount');

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Category } from '#types/structures';
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import type { Category } from '#types/structures';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export async function run(client: FluorineClient, interaction: ChatInputCommandInteraction) {
     const random = Math.floor(Math.random() * 3);

--- a/src/components/avatar.ts
+++ b/src/components/avatar.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { getComponents, getEmbed } from '#util/avatar';
-import { ButtonInteraction } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
 
 export const authorOnly = true;
 

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ActionRowBuilder, APIEmbedField, SelectMenuBuilder, SelectMenuInteraction } from 'discord.js';
-import { ChatInputCommand } from '#types/structures';
+import type { ChatInputCommand } from '#types/structures';
+import { ActionRowBuilder, type APIEmbedField, SelectMenuBuilder, type SelectMenuInteraction } from 'discord.js';
 
 export const authorOnly = true;
 

--- a/src/components/info.ts
+++ b/src/components/info.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { getEmbed, getComponents } from '#util/info';
-import { ButtonInteraction } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
 
 export const authorOnly = true;
 export async function run(client: FluorineClient, interaction: ButtonInteraction, value: string) {

--- a/src/components/listcase.ts
+++ b/src/components/listcase.ts
@@ -1,7 +1,7 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
 import { splitArray } from '#util/splitArr';
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, type ButtonInteraction, ButtonStyle } from 'discord.js';
 
 export const authorOnly = true;
 

--- a/src/context/ai.ts
+++ b/src/context/ai.ts
@@ -1,5 +1,10 @@
-import FluorineClient from '#classes/Client';
-import { ApplicationCommandType, ContextMenuCommandBuilder, MessageContextMenuCommandInteraction } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import {
+    ApplicationCommandType,
+    ContextMenuCommandBuilder,
+    type MessageContextMenuCommandInteraction
+} from 'discord.js';
+
 export async function run(client: FluorineClient, interaction: MessageContextMenuCommandInteraction) {
     const { content } = interaction.targetMessage;
 

--- a/src/context/avatar.ts
+++ b/src/context/avatar.ts
@@ -1,11 +1,11 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { getComponents, getEmbed } from '#util/avatar';
 import {
     ApplicationCommandType,
     ContextMenuCommandBuilder,
-    UserContextMenuCommandInteraction,
-    InteractionReplyOptions,
-    GuildMember
+    GuildMember,
+    type InteractionReplyOptions,
+    type UserContextMenuCommandInteraction
 } from 'discord.js';
 
 export async function run(

--- a/src/context/howgay.ts
+++ b/src/context/howgay.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import { ApplicationCommandType, ContextMenuCommandBuilder, UserContextMenuCommandInteraction } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import { ApplicationCommandType, ContextMenuCommandBuilder, type UserContextMenuCommandInteraction } from 'discord.js';
 import hash from 'murmurhash-v3';
 
 export async function run(

--- a/src/context/list-cases.ts
+++ b/src/context/list-cases.ts
@@ -1,16 +1,16 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
+import { splitArray } from '#util/splitArr';
 import {
     ActionRowBuilder,
     ApplicationCommandType,
     ButtonBuilder,
     ButtonStyle,
     ContextMenuCommandBuilder,
-    InteractionReplyOptions,
+    type InteractionReplyOptions,
     PermissionFlagsBits,
-    UserContextMenuCommandInteraction
+    type UserContextMenuCommandInteraction
 } from 'discord.js';
-import { splitArray } from '#util/splitArr';
 
 export async function run(client: FluorineClient, interaction: UserContextMenuCommandInteraction<'cached'>) {
     const row = new ActionRowBuilder<ButtonBuilder>();

--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import { Guild } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import type { Guild } from 'discord.js';
 
 export async function run(client: FluorineClient, guild: Guild) {
     await client.prisma.config.create({

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
-import { Interaction } from 'discord.js';
-import { ChatInputCommand } from '#types/structures';
+import type FluorineClient from '#classes/Client';
+import type { Interaction } from 'discord.js';
+import type { ChatInputCommand } from '#types/structures';
 
 export async function run(client: FluorineClient, interaction: Interaction) {
     if (interaction.isMessageComponent()) {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Message, OAuth2Scopes } from 'discord.js';
+import type FluorineClient from '#classes/Client';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type Message, OAuth2Scopes } from 'discord.js';
 
 export async function run(client: FluorineClient, message: Message) {
     if (message.author.bot) {

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Message } from 'discord.js';
+import type { Message } from 'discord.js';
 
 export async function run(client: FluorineClient, message: Message) {
     if (!message.content) {

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { Message } from 'discord.js';
+import type { Message } from 'discord.js';
 
 export async function run(client: FluorineClient, oldMessage: Message, newMessage: Message) {
     if (!newMessage || newMessage.content === oldMessage.content) {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { Routes } from 'discord.js';
 import { performance } from 'perf_hooks';
 

--- a/src/types/structures.ts
+++ b/src/types/structures.ts
@@ -1,5 +1,5 @@
-import FluorineClient from '#classes/Client';
-import {
+import type FluorineClient from '#classes/Client';
+import type {
     CommandInteraction,
     ContextMenuCommandBuilder,
     ContextMenuCommandInteraction,

--- a/src/util/avatar.ts
+++ b/src/util/avatar.ts
@@ -1,6 +1,6 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, GuildMember, Interaction, User } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, GuildMember, type Interaction, type User } from 'discord.js';
 
 export function getComponents(
     client: FluorineClient,

--- a/src/util/clean.ts
+++ b/src/util/clean.ts
@@ -1,4 +1,4 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import { inspect } from 'util';
 
 export async function clean(client: FluorineClient, text: unknown): Promise<string> {

--- a/src/util/fragmentText.ts
+++ b/src/util/fragmentText.ts
@@ -1,4 +1,4 @@
-import { CanvasRenderingContext2D } from 'canvas';
+import type { CanvasRenderingContext2D } from 'canvas';
 
 export function fragmentText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number) {
     const words = text.split(' ');

--- a/src/util/info.ts
+++ b/src/util/info.ts
@@ -1,8 +1,8 @@
-import FluorineClient from '#classes/Client';
+import type FluorineClient from '#classes/Client';
 import Embed from '#classes/Embed';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Interaction } from 'discord.js';
-import { join } from 'path';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type Interaction } from 'discord.js';
 import { readdir } from 'fs/promises';
+import { join } from 'path';
 
 export async function getEmbed(client: FluorineClient, interaction: Interaction, page: 'info' | 'stats') {
     const embed = new Embed(client, interaction.locale);


### PR DESCRIPTION
superchupu rewrites every file once again

most of this was made via regex, i only had to manually change 15 files

improves build times by allowing the compiler to make some optimizations

<details>
  <summary>before this change</summary>

  ```sh
  > npm run test:typescript

  > fluorine@2.0.2 test:typescript
  > tsc --noEmit

  fluorine on chore/remove-rest [$] via v18.7.0 took 7s
  ```
</details>

<details>
  <summary>after this change</summary>

  ```sh
  > npm run test:typescript

  > fluorine@2.0.2 test:typescript
  > tsc --noEmit

  fluorine on chore/enforce-type-imports [$!] via v18.7.0 took 6s
```
</details>